### PR TITLE
Add fake packages for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 .DS_Store
 /docs/build/
 /docs/Manifest.toml
-/Manifest.toml
+Manifest.toml

--- a/test/packages/NoDeps.jl/Project.toml
+++ b/test/packages/NoDeps.jl/Project.toml
@@ -1,0 +1,13 @@
+name = "NoDeps"
+uuid = "2520ce14-60c1-53a9-8c5b-16f535851c44"
+version = "0.0.0"
+
+[deps]
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+
+[extras]
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ReTestItems", "Test"]

--- a/test/packages/NoDeps.jl/Project.toml
+++ b/test/packages/NoDeps.jl/Project.toml
@@ -2,9 +2,6 @@ name = "NoDeps"
 uuid = "2520ce14-60c1-53a9-8c5b-16f535851c44"
 version = "0.0.0"
 
-[deps]
-ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-
 [extras]
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/packages/NoDeps.jl/src/NoDeps.jl
+++ b/test/packages/NoDeps.jl/src/NoDeps.jl
@@ -1,0 +1,7 @@
+module NoDeps
+
+export answer
+
+answer() = 42
+
+end

--- a/test/packages/NoDeps.jl/test/runtests.jl
+++ b/test/packages/NoDeps.jl/test/runtests.jl
@@ -1,9 +1,20 @@
-using NoDeps, ReTestItems
+using ReTestItems
+# using NoDeps  # TODO: uncomment when TestEnv
 
 @testitem "NoDeps" begin
+
+    # TODO: remove this hack once we correctly `TestEnv.activate` the right environment.
+    # Also this hack breaks Pkg.test()
+    @eval begin
+        using Pkg
+        Pkg.activate(temp=true)
+        Pkg.develop(path=dirname(@__DIR__))
+    end
     using NoDeps
+
     @test answer() == 42
-    print("NoDeps tests done!")
+    println("NoDeps tests done!")
 end
 
-runtests(NoDeps)
+runtests(@__DIR__)
+# runtests(NoDeps)  # TODO: uncomment when TestEnv

--- a/test/packages/NoDeps.jl/test/runtests.jl
+++ b/test/packages/NoDeps.jl/test/runtests.jl
@@ -1,0 +1,9 @@
+using NoDeps, ReTestItems
+
+@testitem "NoDeps" begin
+    using NoDeps
+    @test answer() == 42
+    print("NoDeps tests done!")
+end
+
+runtests(NoDeps)

--- a/test/packages/README.md
+++ b/test/packages/README.md
@@ -1,0 +1,7 @@
+# test/packages/
+
+This directory contains fake packages which act as integration tests for ReTestItems.jl functionality.
+These packages should have tests that all pass when run either via `ReTestItems.runtests` or via `Pkg.test`.
+
+- *NoDeps.jl* - A package that has no dependencies, and just has some simple `@tests` in the `test/runtests.jl`
+- *TestsInSrc.jl* - A package which has all of its `@testitems` in the `src/` directory.

--- a/test/packages/TestsInSrc.jl/Project.toml
+++ b/test/packages/TestsInSrc.jl/Project.toml
@@ -2,9 +2,6 @@ name = "TestsInSrc"
 uuid = "3520ce14-60c1-53a9-8c5b-16f535851c45"
 version = "0.0.0"
 
-[deps]
-ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-
 [extras]
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/packages/TestsInSrc.jl/Project.toml
+++ b/test/packages/TestsInSrc.jl/Project.toml
@@ -1,0 +1,13 @@
+name = "TestsInSrc"
+uuid = "3520ce14-60c1-53a9-8c5b-16f535851c45"
+version = "0.0.0"
+
+[deps]
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+
+[extras]
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ReTestItems", "Test"]

--- a/test/packages/TestsInSrc.jl/src/TestsInSrc.jl
+++ b/test/packages/TestsInSrc.jl/src/TestsInSrc.jl
@@ -1,0 +1,8 @@
+module TestsInSrc
+
+export foo, bar
+
+include("foo.jl")
+include("bar.jl")
+
+end

--- a/test/packages/TestsInSrc.jl/src/bar.jl
+++ b/test/packages/TestsInSrc.jl/src/bar.jl
@@ -1,0 +1,3 @@
+function bar()
+    return rand(3)
+end

--- a/test/packages/TestsInSrc.jl/src/bar_tests.jl
+++ b/test/packages/TestsInSrc.jl/src/bar_tests.jl
@@ -1,0 +1,9 @@
+@testitem "bar" begin
+    @test bar() isa Vector{Float64}
+    @test length(bar()) == 3
+
+    @testset "bar values" begin
+        @test all(≤(1), bar())
+        @test all(≥(0), bar())
+    end
+end

--- a/test/packages/TestsInSrc.jl/src/foo.jl
+++ b/test/packages/TestsInSrc.jl/src/foo.jl
@@ -1,0 +1,3 @@
+function foo(x)
+    return string("foo_", x)
+end

--- a/test/packages/TestsInSrc.jl/src/foo_test.jl
+++ b/test/packages/TestsInSrc.jl/src/foo_test.jl
@@ -1,0 +1,4 @@
+@testitem "foo" begin
+    @test foo(:bar) == "foo_bar"
+    @test foo(2) == "foo_2"
+end

--- a/test/packages/TestsInSrc.jl/test/runtests.jl
+++ b/test/packages/TestsInSrc.jl/test/runtests.jl
@@ -1,0 +1,3 @@
+# using ReTestItems, TestsInSrc
+
+# runtests(TestsInSrc)


### PR DESCRIPTION
Adds some little packages we can use for testing out the `runtests` functionality

So far, this should work:
```julia
julia> using ReTestItems

julia> runtests("test/packages/NoDeps.jl/")
```
But we need to identify and `TestEnv.activate` the correct Project env before we can remove the current hack in `NoDeps.jl/test/runtests.jl` 

**Note** that these are not part of CI in anyway yet